### PR TITLE
add recursive size to modules

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -123,7 +123,7 @@ function categorize(number) {
 }
 
 
-// Calculate the recrursive dependency size for a module
+// Calculate the recursive dependency size for a module
 // This function has the side effect of updating a passed cache object
 function recursiveSize(m, moduleMap, dependencySizeCache) {
 	var depSize,

--- a/app/app.js
+++ b/app/app.js
@@ -61,8 +61,20 @@ function load(stats) {
 			if(!m) return;
 			origin.moduleUid = m.uid;
 		});
+		chunk.modules.forEach(function(module) {
+			var m = mapModulesIdent["$"+module.identifier], s;
+			if(!m) return;
+			s = m.dependencies.reduce(function(totalSize, dep) {
+				return totalSize + (mapModules[dep.moduleId].size || 0);
+			}, 0);
+			module.recursiveSize = module.size + s;
+		});
 	});
 	stats.modules.forEach(function(module) {
+		var s = module.dependencies.reduce(function(totalSize, dep) {
+			return totalSize + (mapModules[dep.moduleId].size || 0);
+		}, 0);
+		module.recursiveSize = module.size + s;
 		module.dependencies.sort(function(a, b) {
 			if(!a.loc && !b.loc) return 0;
 			if(!a.loc) return 1;

--- a/app/pages/chunk/chunk.jade
+++ b/app/pages/chunk/chunk.jade
@@ -75,6 +75,7 @@
 						th id
 						th name
 						th size
+						th recursive size
 						th chunks
 						th flags
 				tbody
@@ -87,6 +88,7 @@
 									span.btn.btn-success= module.id
 							td: pre: code= module.name.split("!").join("\n")
 							td= require("../../formatSize")(module.size)
+							td= require("../../formatSize")(module.recursiveSize)
 							td
 								each chunk in module.chunks
 									a.btn.btn-info(href="#chunk/#{chunk}")= chunk

--- a/app/pages/module/module.jade
+++ b/app/pages/module/module.jade
@@ -4,7 +4,7 @@
 			table(width="100%"): tbody: tr
 				td: a.btn.btn-success.disabled(href="#module/#{module.uid}")= module.id
 				td: pre: code= module.name.split("!").join("\n")
-		.col-md-3: .well
+		.col-md-2: .well
 			h4 time
 			if module.time
 				code= module.time + "ms"
@@ -13,9 +13,12 @@
 					code= module.timestamp + "ms"
 			else
 				| Compile with <code>--profile</code>.
-		.col-md-3: .well
+		.col-md-2: .well
 			h4 size
 			= require("../../formatSize")(module.size)
+		.col-md-2: .well
+			h4 recursive size
+			= require("../../formatSize")(module.recursiveSize)
 	.row
 		.col-md-3: .well
 			h4 flags

--- a/app/pages/modules/modules.jade
+++ b/app/pages/modules/modules.jade
@@ -4,6 +4,7 @@ table.table.table-condensed
 			th id
 			th name
 			th size
+			th recursive size
 			th chunks
 			th flags
 	tbody
@@ -16,6 +17,7 @@ table.table.table-condensed
 						span.btn.btn-success= module.id
 				td: pre: code= module.name.split("!").join("\n")
 				td= require("../../formatSize")(module.size)
+				td= require("../../formatSize")(module.recursiveSize)
 				td
 					each chunk in module.chunks
 						a.btn.btn-info(href="#chunk/#{chunk}")= chunk


### PR DESCRIPTION
This PR adds recursive size to module views, meaning the size of a module and all its dependencies. It should be useful to determine which are the heaviest dependencies that appear in a large number of chunks.

@bregenspan can you give this a look?
