### PR TITLE
add sorting to module size and recursive size

### DIFF
--- a/app/pages/chunk/chunk.jade
+++ b/app/pages/chunk/chunk.jade
@@ -74,8 +74,8 @@
 					tr
 						th id
 						th name
-						th size
-						th recursive size
+						th: a#size(href='#') size
+						th: a#recursive-size(href='#') recursive size
 						th chunks
 						th flags
 				tbody

--- a/app/pages/chunk/page.js
+++ b/app/pages/chunk/page.js
@@ -1,5 +1,6 @@
 var app = require("../../app");
 var modulesGraph = require("../../graphs/modules");
+var sortTable = require("../../sortTable");
 
 module.exports = function(id) {
 	id = parseInt(id, 10);
@@ -11,6 +12,14 @@ module.exports = function(id) {
 	}));
 	modulesGraph.show();
 	modulesGraph.setActiveChunk(id);
+	$('#size').click(function(e){
+		e.preventDefault();
+		sortTable(3);
+	});
+	$('#recursive-size').click(function(e){
+		e.preventDefault();
+		sortTable(4);
+	});
 	return function() {
 		modulesGraph.hide();
 	}

--- a/app/sortTable.js
+++ b/app/sortTable.js
@@ -1,0 +1,41 @@
+module.exports = function sortTable(colNumber) {
+	var table = document.querySelectorAll('tbody')[1];
+	var	sizeKey = 'data-size-' + colNumber;
+	var	sortKey = 'data-sort-desc-' + colNumber;
+
+	// Sort table desc initially, then alternate
+	if (!table.hasAttribute(sortKey)) {
+		table.setAttribute(sortKey, 1);
+	}
+	var sortDesc = parseInt(table.getAttribute(sortKey), 0);
+	if (sortDesc) {
+		table.setAttribute(sortKey, 0);
+	} else {
+		table.setAttribute(sortKey, 1);
+	}
+
+	Array.prototype.slice.apply(table.querySelectorAll('tr')).forEach(function (el) {
+		var size = el.querySelector('td:nth-of-type(' + colNumber + ')').innerHTML;
+		var num = origNum = parseInt(size,0);
+		if (size.indexOf('KiB') > -1) {
+			num = num * 1024;
+		} else if (size.indexOf('MiB') > -1) {
+			num = num * 1024 * 1024;
+		}
+		el.setAttribute(sizeKey, num);
+	});
+
+	var rows = Array.prototype.slice.apply(table.querySelectorAll('tr'));
+	rows.forEach(function (row) {
+		var currentSize = parseInt(row.getAttribute(sizeKey), 0);
+		var moved = false;
+		Array.prototype.slice.apply(table.querySelectorAll('tr')).forEach(function (irow) {
+			var irowSize = parseInt(irow.getAttribute(sizeKey), 0);
+			var insertBefore = sortDesc ? currentSize >= irowSize : currentSize <= irowSize; 
+			if (!moved && insertBefore) {
+				irow.parentNode.insertBefore(row, insertBefore ? irow : irow.nextSibling);
+				moved = true;
+			}
+		});
+	});
+}


### PR DESCRIPTION
This is a quick PR to add the (slightly modified) sorting code from @bregenspan's gist to the analyse tool's chunk view. Note that this is really a hack and will almost certain be replaced with a better sort that sorts the underlying modules collection. However, this was quick and dirty and the hack is well-encapsulated so don't think there's much harm is using this for now until I have a chance to implement a better solution.
