### PR TITLE
add tooltips to easily see which chunks a module belongs to

### DIFF
--- a/app/pages/chunk/chunk.jade
+++ b/app/pages/chunk/chunk.jade
@@ -91,7 +91,7 @@
 							td= require("../../formatSize")(module.recursiveSize)
 							td
 								each chunk in module.chunks
-									a.btn.btn-info(href="#chunk/#{chunk}")= chunk
+									a.btn.btn-info(href="#chunk/#{chunk}", title="#{mapChunks[chunk].names.join(',')}")= chunk
 									= " "
 							td
 								if module.built

--- a/app/pages/chunk/page.js
+++ b/app/pages/chunk/page.js
@@ -8,7 +8,8 @@ module.exports = function(id) {
 	$(".page").html(require("./chunk.jade")({
 		stats: app.stats,
 		id: id,
-		chunk: app.mapChunks[id]
+		chunk: app.mapChunks[id],
+		mapChunks: app.mapChunks
 	}));
 	modulesGraph.show();
 	modulesGraph.setActiveChunk(id);


### PR DESCRIPTION
Another quick hack we can use to help analyze webpack modules/chunks. Eventually this should be abstracted and used everywhere in the tool, but I don't think that's the best use of time right now. I've created a trello ticket to remember to do this:

https://trello.com/c/lRRCalxn/64-abstract-tooltips-for-chunks-in-the-analyse-tool

NOTE: I'm just going to merge this right away since it's mostly for my benefit right now.
