### PR TITLE
support nonnumberic chunk ids on chunk pages

### DIFF
--- a/app/pages/chunk/page.js
+++ b/app/pages/chunk/page.js
@@ -3,7 +3,10 @@ var modulesGraph = require("../../graphs/modules");
 var sortTable = require("../../sortTable");
 
 module.exports = function(id) {
-	id = parseInt(id, 10);
+	var parsedId = parseInt(id, 10);
+	if (parsedId) {
+		id = parsedId;
+	}
 	document.title = "chunk " + id;
 	$(".page").html(require("./chunk.jade")({
 		stats: app.stats,


### PR DESCRIPTION
This is a simple pull request to allow nonnumeric chunk ids when pulling up the info for a specific chunk. Currently the app expects a number for the chunk id, which causes errors when attempting to inspect a chunk with a nonnumeric id like "Post".

@gawkermedia/performance @bregenspan can you please give this a quick look?
